### PR TITLE
Add max and min width to hover.css

### DIFF
--- a/chrome/userChrome-hover.css
+++ b/chrome/userChrome-hover.css
@@ -26,8 +26,8 @@ There's two main sidebar components.
     position: relative !important;
     background: var(--sidebar-background-color) !important;
     padding-top: calc(-1 * var(--menubar-height));
-    min-width: 0px;
-    max-width: 0px;
+    min-width: var(--initial-width) !important;
+    max-width: var(--initial-width) !important;
 }
 
 #sidebar-header,


### PR DESCRIPTION
Added a max and min width to the *hover.css so that it respects the unfocused tree style tab. 

![image](https://user-images.githubusercontent.com/22812015/101153586-eeea7f00-3624-11eb-8000-4d49c0e128fd.png)

@astroryan12 
